### PR TITLE
add rc2026 initial marker/team changes

### DIFF
--- a/robot/game_config/startup_poems.py
+++ b/robot/game_config/startup_poems.py
@@ -1,7 +1,6 @@
 from random import randint
 
 class POEM_ON_STARTUP:
-    ## These jokes are terrible, (ChatGPT 4o Generated)
     jokes = [
         "Why don't dragons tell secrets? \
             Because they always breathe fire!",

--- a/robot/game_config/targets.py
+++ b/robot/game_config/targets.py
@@ -5,15 +5,13 @@ Defines each target type, for example sheep, lair or gem.
 """
 class TARGET_TYPE(enum.Enum): 
     
-    ## These easter eggs are locations that the corresponding gems were found (ChatGPT 4o Generated)
-    SHEEP = "Baa" # This matches T0, for example.
-    GEM = "Shiny"
-    LAIR = "Dangerous"
+    SUPPLY_L = "SUPPLY_L" # This matches T0, for example.
+    SUPPLY_H = "SUPPLY_H"
+    
     # There is no T value for ARENA, so there is no way that the assignment of team to a marker can accidentally assign ARENA if the logic goes wrong.
 
     NONE = "NONE"  ## This is only used when no other owning team is available for undefined IDs, this should never actually happen in-game.
 
-    T0 = "Baa"
-    T1 = "Shiny"
-    T2 = "Dangerous"
+    T0 = "SUPPLY_L"
+    T1 = "SUPPLY_H"
 

--- a/robot/game_config/teams.py
+++ b/robot/game_config/teams.py
@@ -7,18 +7,17 @@ that the school will be competing as.
 """
 class TEAM(enum.Enum): 
     
-    ## These easter eggs are locations that the corresponding gems were found (ChatGPT 4o Generated)
-    RUBY = "Mogok Valley, Myanmar (Burma)" # This matches T0, for example.
-    JADE = "Hetian (Hotan), Xinjiang, China"
-    TOPAZ = "St. John's Island (Zabargad Island), Egypt"
-    DIAMOND = "Golconda, India"
+    RED = "RED" # This matches T0, for example.
+    GREEN = "GREEN"
+    YELLOW = "YELLOW"
+    BLUE = "BLUE"
     ARENA = "Nothing!"
     # There is no T value for ARENA, so there is no way that the assignment of team to a marker can accidentally assign ARENA if the logic goes wrong.
 
     NONE = "NONE"  ## This is only used when no other owning team is available for undefined IDs, this should never actually happen in-game.
 
-    T0 = "Mogok Valley, Myanmar (Burma)"
-    T1 = "Hetian (Hotan), Xinjiang, China"
-    T2 = "St. John's Island (Zabargad Island), Egypt"
-    T3 = "Golconda, India"
+    T0 = "RED"
+    T1 = "GREEN"
+    T2 = "YELLOW"
+    T3 = "BLUE"
 

--- a/robot/wrapper.py
+++ b/robot/wrapper.py
@@ -67,7 +67,7 @@ class Robot():
                  start_enable_5v = True,
                  ):
 
-        self.zone = game_config.TEAM.RUBY
+        self.zone = game_config.TEAM.RED
         self.mode = "competition"
         self._max_motor_voltage = max_motor_voltage
 


### PR DESCRIPTION
initial marker changes for rc2026, chosen ranges (incl):
- 0-23: supply low
- 24-31: supply high
- 88-91: pillar
- 92-99: zone division
- 100+: arena wall
---
other changes:
- change team names (currently generic, as names are undecided as of yet)
- change other relevant ids